### PR TITLE
fix: correct homebrew tap and go install references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ A command-line interface for managing Jira Cloud tickets.
 ### Homebrew (macOS)
 
 ```bash
-brew tap open-cli-collective/jira-ticket-cli
-brew install jira-ticket-cli
+brew tap open-cli-collective/tap
+brew install --cask jira-ticket-cli
 ```
+
+> **Note:** Homebrew installation will be available after the first release.
 
 ### Go Install
 
 ```bash
-go install github.com/open-cli-collective/jira-ticket-cli/cmd/jira-ticket-cli@latest
+go install github.com/piekstra/jira-ticket-cli/cmd/jira-ticket-cli@latest
 ```
 
 ### Binary Download


### PR DESCRIPTION
## Summary

Fix installation instructions to use correct paths.

## Changes

- Update homebrew tap from non-existent `open-cli-collective/jira-ticket-cli` to shared `open-cli-collective/tap`
- Add `--cask` flag for homebrew install (to match other CLIs in the org)
- Add note that homebrew will be available after first release
- Fix `go install` to use current module path (`piekstra/jira-ticket-cli`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update