### PR TITLE
chore: unify Claude Code settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go:*)",
+      "Bash(golangci-lint:*)",
+      "Bash(goimports:*)",
+      "Bash(gofmt:*)",
+      "Bash(make:*)",
+      "Bash(goreleaser:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(rm -rf bin/:*)",
+      "Bash(rm -rf dist/:*)",
+      "Bash(rm coverage:*)",
+      "Bash(./bin/jira-ticket-cli:*)",
+      "WebFetch(domain:go.dev)",
+      "WebFetch(domain:pkg.go.dev)",
+      "WebFetch(domain:golang.org)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:goreleaser.com)",
+      "WebFetch(domain:golangci-lint.run)",
+      "WebFetch(domain:*.atlassian.com)",
+      "WebFetch(domain:*.atlassian.net)",
+      "WebFetch(domain:developer.atlassian.com)",
+      "WebSearch"
+    ],
+    "ask": [
+      "Bash(git rebase:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)"
+    ],
+    "deny": [
+      "Bash(goreleaser release:*)",
+      "Bash(goreleaser publish:*)",
+      "Bash(goreleaser announce:*)",
+      "Bash(goreleaser continue:*)",
+      "Bash(git filter-branch:*)",
+      "Bash(git filter-repo:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf .*:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Standardize Claude Code settings.json for Go development
- Allow common Go development commands (go, make, golangci-lint, goreleaser, git, gh)
- Add goreleaser release/publish/announce/continue to deny list (CI-only operations)
- Add git rebase and force push to ask list
- Add dangerous rm commands to deny list

Closes #10

## Test plan
- [ ] Verify settings.json is properly formatted
- [ ] Confirm allowed commands work as expected
- [ ] Confirm denied commands are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)