### PR TITLE
feat: add smart commit filtering to auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,8 +2,11 @@ name: Auto Release
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: write
@@ -11,8 +14,12 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    # Skip if commit is from the release workflow (avoid loops)
-    if: "!startsWith(github.event.head_commit.message, 'chore:') && !startsWith(github.event.head_commit.message, 'chore(')"
+    # Only release on feat: or fix: commits (semantic versioning)
+    if: >-
+      startsWith(github.event.head_commit.message, 'feat:') ||
+      startsWith(github.event.head_commit.message, 'feat(') ||
+      startsWith(github.event.head_commit.message, 'fix:') ||
+      startsWith(github.event.head_commit.message, 'fix(')
     steps:
       # TAP_GITHUB_TOKEN (a PAT) is required here instead of the default GITHUB_TOKEN
       # because tag pushes made with GITHUB_TOKEN do not trigger other workflows.


### PR DESCRIPTION
## Summary

Add dual-gate release filtering to avoid noise releases from documentation, CI, or other non-code changes.

## Changes

### Path Filter
Only trigger on Go source changes:
```yaml
paths:
  - '**.go'
  - 'go.mod'
  - 'go.sum'
```

### Commit Filter
Only release on semantic versioning commits:
```yaml
if: >-
  startsWith(github.event.head_commit.message, 'feat:') ||
  startsWith(github.event.head_commit.message, 'feat(') ||
  startsWith(github.event.head_commit.message, 'fix:') ||
  startsWith(github.event.head_commit.message, 'fix(')
```

## Behavior Change

| Commit Type | Before | After |
|-------------|--------|-------|
| `feat: add feature` | Release | Release |
| `fix: bug fix` | Release | Release |
| `docs: update README` | Release | No release |
| `ci: update workflow` | Release | No release |
| `chore: cleanup` | No release | No release |
| `refactor: code changes` | Release | No release |

## PAT Configuration

The workflow already uses `TAP_GITHUB_TOKEN` for checkout, which ensures tag pushes trigger downstream workflows. No change needed.

Closes #7