### PR TITLE
feat: add delete command for comments

### DIFF
--- a/api/comments.go
+++ b/api/comments.go
@@ -58,3 +58,17 @@ func (c *Client) AddComment(issueKey, commentBody string) (*Comment, error) {
 
 	return &comment, nil
 }
+
+// DeleteComment deletes a comment from an issue
+func (c *Client) DeleteComment(issueKey, commentID string) error {
+	if issueKey == "" {
+		return ErrIssueKeyRequired
+	}
+	if commentID == "" {
+		return fmt.Errorf("comment ID is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/issue/%s/comment/%s", c.BaseURL, url.PathEscape(issueKey), url.PathEscape(commentID))
+	_, err := c.delete(urlStr)
+	return err
+}


### PR DESCRIPTION
## Summary

- Adds `comments delete` command to remove comments from issues
- Usage: `jira-ticket-cli comments delete <issue-key> <comment-id>`

## Test plan

- [x] Tested locally with real Jira instance
- [x] Build passes